### PR TITLE
Set uv required-version >=0.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,5 @@ module-name = "item_estimation"
 module-root = ""
 
 [tool.uv]
+required-version = ">=0.11.6"
 exclude-newer = "7 days"


### PR DESCRIPTION
## Summary
- add `required-version = ">=0.11.6"` to `[tool.uv]` for uv-managed project(s)

## Verification
- parsed updated `pyproject.toml` files with `tomllib`
