### PR TITLE
Refresh uv lock exclude-newer metadata

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-04-07T08:21:47.600888Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "contourpy"
 version = "1.3.3"


### PR DESCRIPTION
## Summary
- refresh `uv.lock` with `uv 0.11.6` so it records `exclude-newer-span = "P7D"`

## Verification
- ran `uv lock` with `uv 0.11.6`
- verified `pyproject.toml` contains `exclude-newer = "7 days"` and `uv.lock` contains `exclude-newer-span = "P7D"`
